### PR TITLE
[Feat] /#6/movie detail

### DIFF
--- a/src/components/Movie/MovieCardImage.tsx
+++ b/src/components/Movie/MovieCardImage.tsx
@@ -1,0 +1,34 @@
+import { lazy, memo } from 'react';
+import styled from 'styled-components';
+
+const LazyImage = lazy(() => import('@components/common/Image/LazyImage'));
+
+const MovieCardImage = memo(
+  ({ poster_path, title }: { poster_path: string; title: string }) => {
+    return (
+      <StyledList>
+        <StyledCard>
+          <LazyImage src={poster_path} alt={title} />
+        </StyledCard>
+      </StyledList>
+    );
+  },
+);
+
+MovieCardImage.displayName = 'MovieCardImage';
+
+const StyledList = styled.li`
+  flex: 1;
+  position: relative;
+  max-width: 300px;
+  max-height: 420px;
+  box-sizing: border-box;
+`;
+
+const StyledCard = styled.div`
+  display: flex;
+  flex-direction: column;
+  border-radius: 8px;
+`;
+
+export default MovieCardImage;

--- a/src/components/Movie/MovieDetail.tsx
+++ b/src/components/Movie/MovieDetail.tsx
@@ -1,0 +1,47 @@
+import assert from 'assert';
+import { memo } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import MovieInfo from '@components/Movie/MovieInfo';
+import MovieReview from '@components/Movie/MovieReview';
+import MovieRecommand from '@components/Movie/MovieRecommand';
+import styled from 'styled-components';
+
+const MovieDetail = memo(() => {
+  const { movieId } = useParams();
+  assert(movieId);
+  const navigate = useNavigate();
+  return (
+    <div>
+      <MovieInfo movieId={movieId} />
+      <MovieReview movieId={movieId} />
+      <MovieRecommand movieId={movieId} />
+      <StyledButtonWrapper>
+        <StyledButton onClick={() => navigate('/movie-list')}>
+          Back to List
+        </StyledButton>
+      </StyledButtonWrapper>
+    </div>
+  );
+});
+
+MovieDetail.displayName = 'MovieDetail';
+
+const StyledButtonWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  margin-top: 20px;
+`;
+
+const StyledButton = styled.button`
+  width: 100%;
+  max-width: 400px;
+  padding: 0.8rem 1.2rem;
+  background-color: var(--gray-4);
+  font-size: 16px;
+  font-weight: 400;
+  border-radius: 8px;
+  color: var(--white);
+`;
+
+export default MovieDetail;

--- a/src/components/Movie/MovieInfo.tsx
+++ b/src/components/Movie/MovieInfo.tsx
@@ -1,0 +1,120 @@
+import MovieCardImage from './MovieCardImage';
+import styled from 'styled-components';
+import StarRate from '@components/common/StarRate';
+import LikeButton from '@components/common/Button/LikeButton';
+import Tag from '@components/common/Tag';
+import { useGetMovieDetail } from '@hooks/useGetQueries';
+
+const MovieInfo = ({ movieId }: { movieId: string }) => {
+  const { data: movie } = useGetMovieDetail(movieId);
+  return (
+    <StyledLayout>
+      <StyledTitleContainer>
+        <h1>{movie.title}</h1>
+        <StyledUnderline />
+      </StyledTitleContainer>
+      <StyledInfoContainer>
+        <MovieCardImage poster_path={movie.poster_path} title={movie.title} />
+        <StyledInfo>
+          <StyledFirstLineBox>
+            <StyledLineBox>
+              <span>Rate.</span>
+              <StyledRateNumber>
+                ({movie.vote_average.toFixed(2)})
+              </StyledRateNumber>
+              <StarRate rate={movie.vote_average} color={true} />
+            </StyledLineBox>
+            <LikeButton title={movie.title} id={movie.id} />
+          </StyledFirstLineBox>
+          <StyledDateBox>
+            <span>Release Date.</span>
+            <StyledDate>{movie.release_date.split('-').join('.')}</StyledDate>
+          </StyledDateBox>
+          <StyledGenreBox>
+            {movie.genres.map((genre) => (
+              <Tag key={genre.id} text={genre.name} />
+            ))}
+          </StyledGenreBox>
+          <StyledOverviewBox>{movie.overview}</StyledOverviewBox>
+        </StyledInfo>
+      </StyledInfoContainer>
+    </StyledLayout>
+  );
+};
+
+MovieInfo.displayName = 'MovieInfo';
+
+const StyledLayout = styled.div`
+  margin: 40px 0;
+  padding: 0 8px;
+`;
+
+const StyledTitleContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--primary);
+  margin-bottom: 40px;
+`;
+
+const StyledUnderline = styled.div`
+  width: 50px;
+  height: 1px;
+  background-color: var(--primary);
+`;
+
+const StyledInfoContainer = styled.div`
+  display: flex;
+  gap: 24px;
+`;
+
+const StyledInfo = styled.div`
+  flex: 2;
+  border: 1px solid var(--gray-4);
+  border-radius: 8px;
+  padding: 16px;
+`;
+
+const StyledFirstLineBox = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const StyledLineBox = styled.div`
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  color: var(--gray-1);
+  gap: 4px;
+`;
+
+const StyledDateBox = styled.div`
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  color: var(--gray-1);
+  gap: 4px;
+  margin: 8px 0;
+`;
+
+const StyledDate = styled.span`
+  color: var(--primary);
+`;
+
+const StyledRateNumber = styled.span`
+  color: var(--gray-3);
+`;
+
+const StyledGenreBox = styled.ul`
+  margin: 20px 0;
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+`;
+
+const StyledOverviewBox = styled.div`
+  padding: 4px 0;
+`;
+
+export default MovieInfo;

--- a/src/components/Movie/MovieList.tsx
+++ b/src/components/Movie/MovieList.tsx
@@ -1,0 +1,48 @@
+import { useGetAllMovies } from '@hooks/useGetQueries';
+import { memo, useState } from 'react';
+import MovieCard from '@components/Movie/MovieCard';
+import Pagination from '@components/common/Pagination';
+import styled from 'styled-components';
+import { media } from '@styles/media';
+
+const MovieList = memo(({ sortType }: { sortType: string }) => {
+  const [currentPage, setCurrentPage] = useState<number>(1);
+  const { data: movies } = useGetAllMovies(currentPage, sortType);
+
+  const handlePageChange = (pageNumber: number) => {
+    setCurrentPage(pageNumber);
+  };
+
+  return (
+    <>
+      <StyledUl>
+        {movies.results.map((movie) => (
+          <MovieCard key={movie.id} {...movie}></MovieCard>
+        ))}
+      </StyledUl>
+      <Pagination
+        currentPage={movies.page}
+        totalPages={movies.total_pages}
+        onPageChange={handlePageChange}
+      />
+    </>
+  );
+});
+
+MovieList.displayName = 'MoviePosts';
+
+const StyledUl = styled.ul`
+  display: grid;
+  grid-template-columns: repeat(4, minmax(150px, 1fr));
+  justify-items: center;
+  align-items: center;
+  gap: 10px;
+  ${media.tablet`
+  grid-template-columns: repeat(3, minmax(150px, 1fr));
+  `}
+  ${media.phone`
+  grid-template-columns: repeat(2, minmax(150px, 1fr));
+  `}
+`;
+
+export default MovieList;

--- a/src/components/Movie/MovieRecommand.tsx
+++ b/src/components/Movie/MovieRecommand.tsx
@@ -1,0 +1,40 @@
+import Carousel from '@components/common/Carousel';
+import { useGetRecommendation } from '@hooks/useGetQueries';
+import styled from 'styled-components';
+
+const MovieRecommand = ({ movieId }: { movieId: string }) => {
+  const { data: recommands } = useGetRecommendation(movieId);
+  return (
+    <StyledWrapper>
+      <StyledTitleContainer>
+        <h1>More Like This</h1>
+        <StyledUnderline />
+      </StyledTitleContainer>
+      <Carousel movies={recommands} />
+    </StyledWrapper>
+  );
+};
+
+MovieRecommand.displayName = 'MovieRecommand';
+
+const StyledWrapper = styled.div`
+  margin-top: 20px;
+  padding: 0 8px;
+`;
+
+const StyledTitleContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  font-size: 18px;
+  font-weight: 500;
+  color: var(--primary);
+  margin-bottom: 8px;
+`;
+
+const StyledUnderline = styled.div`
+  width: 64px;
+  height: 1px;
+  background-color: var(--gray-4);
+`;
+
+export default MovieRecommand;

--- a/src/components/Movie/MovieReview.tsx
+++ b/src/components/Movie/MovieReview.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react';
+import ReviewItem from '@components/common/Review/ReviewItem';
+import styled from 'styled-components';
+import { useGetMovieReviews } from '@hooks/useGetQueries';
+
+const MovieReview = ({ movieId }: { movieId: string }) => {
+  const [showAllReviews, setShowAllReviews] = useState<boolean>(false);
+  const { data: reviews } = useGetMovieReviews(movieId);
+  const review = reviews.results;
+
+  return (
+    <StyledReviewContainer>
+      <StyledTitleContainer>
+        <h1>Reviews</h1>
+        <StyledUnderline />
+      </StyledTitleContainer>
+      {review.length > 0 ? (
+        <>
+          <ReviewItem key={review[0].id} {...review[0]} />
+          {review.length > 1 && !showAllReviews && (
+            <StyledButtonContainer>
+              <StyledReadAllButton onClick={() => setShowAllReviews(true)}>
+                Read All Reviews
+              </StyledReadAllButton>
+            </StyledButtonContainer>
+          )}
+          {showAllReviews &&
+            review
+              .slice(1)
+              .map((reviewItem) => (
+                <ReviewItem key={reviewItem.id} {...reviewItem} />
+              ))}
+        </>
+      ) : (
+        <StyledNoneReviewBox>
+          <p>No Reviews Yet</p>
+        </StyledNoneReviewBox>
+      )}
+    </StyledReviewContainer>
+  );
+};
+
+MovieReview.displayName = 'MovieReview';
+
+const StyledReviewContainer = styled.div`
+  padding: 0 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const StyledTitleContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  font-size: 18px;
+  font-weight: 500;
+  color: var(--primary);
+  margin-bottom: 8px;
+`;
+
+const StyledUnderline = styled.div`
+  width: 64px;
+  height: 1px;
+  background-color: var(--gray-4);
+`;
+
+const StyledButtonContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+`;
+
+const StyledReadAllButton = styled.button`
+  color: var(--gray-3);
+  font-size: 14px;
+  border-bottom: 1px solid var(--gray-3);
+  padding: 0;
+`;
+
+const StyledNoneReviewBox = styled.div`
+  width: 100%;
+  height: 200px;
+  position: relative;
+  padding: 12px;
+  border: 1px solid var(--gray-4);
+  border-radius: 8px;
+  color: var(--gray-3);
+  font-size: 18px;
+  font-weight: 500;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export default MovieReview;

--- a/src/components/Movie/RecommandMovieItem.tsx
+++ b/src/components/Movie/RecommandMovieItem.tsx
@@ -1,0 +1,120 @@
+import { MovieProps } from 'src/@types/movie';
+import MovieCardImage from '@components/Movie/MovieCardImage';
+import styled from 'styled-components';
+import StarRate from '@components/common/StarRate';
+import rightArrow from '@assets/icons/arrow_right_black.svg';
+import { useNavigate } from 'react-router-dom';
+import { textEllipsisStyle } from '@styles/styleConstants';
+
+const RecommandMovieItem = ({
+  id,
+  title,
+  poster_path,
+  vote_average,
+  overview,
+}: MovieProps) => {
+  const navigate = useNavigate();
+  return (
+    <StyledLayout>
+      <StyledInfoContainer>
+        <MovieCardImage poster_path={poster_path} title={title} />
+        <StyledInfo>
+          <div>
+            <StyledTitle>{title}</StyledTitle>
+            <StyledFirstLineBox>
+              <StyledLineBox>
+                <StarRate rate={vote_average} color={true} />
+                <StyledRateNumber>{vote_average.toFixed(2)}</StyledRateNumber>
+              </StyledLineBox>
+            </StyledFirstLineBox>
+            <StyledOverviewBox>{overview}</StyledOverviewBox>
+          </div>
+          <StyledButtonWrapper onClick={() => navigate(`/movie-detail/${id}`)}>
+            <StyledText>View Details</StyledText>
+            <StyledArrow alt="arrow" src={rightArrow} />
+          </StyledButtonWrapper>
+        </StyledInfo>
+      </StyledInfoContainer>
+    </StyledLayout>
+  );
+};
+
+RecommandMovieItem.displayName = 'RecommandMovieItem';
+
+const StyledLayout = styled.div`
+  margin: 40px 0;
+  padding: 12px;
+  background-color: var(--gray-7);
+  border-radius: 8px;
+`;
+
+const StyledInfoContainer = styled.div`
+  display: flex;
+  gap: 24px;
+`;
+
+const StyledInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  flex: 2;
+  padding: 16px 0;
+`;
+
+const StyledTitle = styled.h2`
+  font-size: 16px;
+  font-weight: 500;
+  color: var(--gray-1);
+  margin-bottom: 4px;
+`;
+
+const StyledFirstLineBox = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 4px;
+`;
+
+const StyledLineBox = styled.div`
+  font-weight: 400;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  color: var(--gray-1);
+  gap: 4px;
+`;
+
+const StyledRateNumber = styled.span`
+  font-size: 12px;
+  color: var(--gray-3);
+`;
+
+const StyledOverviewBox = styled.div`
+  font-weight: 400;
+  font-size: 14px;
+  padding: 4px 0;
+  ${textEllipsisStyle}
+  -webkit-line-clamp: 10;
+  line-height: 16px;
+`;
+
+const StyledButtonWrapper = styled.button`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  width: 100%;
+  margin-top: 12px;
+`;
+
+const StyledText = styled.div`
+  color: var(--gray-1);
+  font-size: 12px;
+  line-height: 19px;
+  height: 18px;
+`;
+
+const StyledArrow = styled.img`
+  width: 18px;
+  height: 18px;
+`;
+
+export default RecommandMovieItem;

--- a/src/components/common/Button/LikeButton.tsx
+++ b/src/components/common/Button/LikeButton.tsx
@@ -1,0 +1,62 @@
+import { memo, useContext } from 'react';
+import styled from 'styled-components';
+import likeIcon from '@assets/icons/like.svg';
+import ActivelikeIcon from '@assets/icons/like-active.svg';
+import { useGetMovieState } from '@hooks/useGetQueries';
+import { usePostLike } from '@hooks/usePostMutations';
+import { ModalContext } from '@context/ModalContext';
+import AddModal from '@components/common/Modal/AddModal';
+import DeleteModal from '@components/common/Modal/DeleteModal';
+import { useNavigate } from 'react-router-dom';
+
+type ButtonProps = React.HTMLAttributes<HTMLButtonElement> & {
+  id: string;
+  title: string;
+};
+
+const LikeButton = memo(({ id, title }: ButtonProps) => {
+  const navigate = useNavigate();
+  const { openModal } = useContext(ModalContext);
+  const { data: movieState } = useGetMovieState(id);
+  const { mutate: like } = usePostLike();
+
+  const onLike = async () => {
+    if (movieState.favorite) {
+      like({ media_id: id, favorite: false });
+      openModal(<DeleteModal title={title} />).catch(() => false);
+    } else {
+      like({ media_id: id, favorite: true });
+      const flag = await openModal(<AddModal title={title} />).catch(
+        () => false,
+      );
+      if (flag) navigate(`/movie-list/favorite`);
+    }
+  };
+
+  return (
+    <StyledButton type="button" onClick={onLike}>
+      <StyledLogo
+        alt="like"
+        src={movieState.favorite ? ActivelikeIcon : likeIcon}
+      />
+    </StyledButton>
+  );
+});
+
+LikeButton.displayName = 'LikeButton';
+
+const StyledButton = styled.button`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: var(--white);
+  border: none;
+  gap: 4px;
+`;
+
+const StyledLogo = styled.img`
+  width: 24px;
+  height: 24px;
+`;
+
+export default LikeButton;

--- a/src/components/common/Carousel/index.tsx
+++ b/src/components/common/Carousel/index.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react';
+import { MovieProps } from 'src/@types/movie';
+import styled from 'styled-components';
+import RecommandMovieItem from '@components/Movie/RecommandMovieItem';
+import arrow_right from '@assets/icons/arrow_right_primary.svg';
+import arrow_left from '@assets/icons/arrow_left_primary.svg';
+
+const Carousel = ({ movies }: { movies: MovieProps[] }) => {
+  const [currentSlide, setCurrentSlide] = useState(0);
+
+  const nextSlide = () => {
+    setCurrentSlide((prevSlide) =>
+      prevSlide === movies.length - 1 ? 0 : prevSlide + 1,
+    );
+  };
+
+  const prevSlide = () => {
+    setCurrentSlide((prevSlide) =>
+      prevSlide === 0 ? movies.length - 1 : prevSlide - 1,
+    );
+  };
+
+  return (
+    <StyledCarouselWrapper>
+      {movies.length ? (
+        <>
+          <StyledButton onClick={prevSlide}>
+            <StyledArrow src={arrow_left} alt="arrow" />
+          </StyledButton>
+          <StyledCarouselContainer>
+            {movies.map((movie, index) => (
+              <Slide key={index} $isActive={index === currentSlide}>
+                <RecommandMovieItem {...movie} />
+              </Slide>
+            ))}
+          </StyledCarouselContainer>
+          <StyledButton onClick={nextSlide}>
+            <StyledArrow src={arrow_right} alt="arrow" />
+          </StyledButton>
+        </>
+      ) : (
+        <StyledNoneResultBox>No Recommand Movies</StyledNoneResultBox>
+      )}
+    </StyledCarouselWrapper>
+  );
+};
+
+Carousel.displayName = 'Carousel';
+
+const StyledCarouselWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+`;
+
+const StyledCarouselContainer = styled.div`
+  diplay: flex;
+  width: 636px;
+  overflow: hidden;
+`;
+
+const Slide = styled.div<{ $isActive: boolean }>`
+  display: ${({ $isActive }) => ($isActive ? 'block' : 'none')};
+`;
+
+const StyledButton = styled.button`
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+`;
+
+const StyledArrow = styled.img`
+  width: 16px;
+  height; 16px;
+`;
+
+const StyledNoneResultBox = styled.div`
+  width: 100%;
+  height: 200px;
+  position: relative;
+  padding: 12px;
+  border: 1px solid var(--gray-4);
+  border-radius: 8px;
+  color: var(--gray-3);
+  font-size: 18px;
+  font-weight: 500;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export default Carousel;

--- a/src/components/common/Pagination/index.tsx
+++ b/src/components/common/Pagination/index.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import styled from 'styled-components';
+import arrow_double_left from '@assets/icons/arrow_double_left.svg';
+import arrow_double_right from '@assets/icons/arrow_double_right.svg';
+import arrow_left from '@assets/icons/arrow_left.svg';
+import arrow_right from '@assets/icons/arrow_right.svg';
+
+interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (pageNumber: number) => void;
+}
+
+const Pagination = ({
+  currentPage,
+  totalPages,
+  onPageChange,
+}: PaginationProps) => {
+  const startPage = Math.max(1, currentPage - 2);
+  const endPage = Math.min(500, startPage + 4);
+  const pageNumbers = Array.from(
+    { length: endPage + 1 - startPage },
+    (_, i) => startPage + i,
+  );
+
+  return (
+    <StyledPageUl>
+      {currentPage !== 1 && (
+        <li>
+          <StyledButtonContainer>
+            <StyledButton
+              src={arrow_double_left}
+              alt="처음으로"
+              onClick={() => onPageChange(1)}
+            />
+            <StyledButton
+              src={arrow_left}
+              alt="이전"
+              onClick={() => onPageChange(currentPage - 1)}
+            />
+          </StyledButtonContainer>
+        </li>
+      )}
+      {pageNumbers.map((pageNumber) => (
+        <li key={pageNumber}>
+          <StyledNumber
+            $isActive={pageNumber === currentPage}
+            onClick={() => onPageChange(pageNumber)}
+          >
+            {pageNumber}
+          </StyledNumber>
+        </li>
+      ))}
+      {currentPage !== totalPages && (
+        <li>
+          <StyledButtonContainer>
+            <StyledButton
+              src={arrow_right}
+              alt="다음으로"
+              onClick={() => onPageChange(currentPage + 1)}
+            />
+            <StyledButton
+              src={arrow_double_right}
+              alt="맨뒤로"
+              onClick={() => onPageChange(500)}
+            />
+          </StyledButtonContainer>
+        </li>
+      )}
+    </StyledPageUl>
+  );
+};
+
+const StyledPageUl = styled.ul`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 30px 0;
+`;
+
+const StyledButtonContainer = styled.div`
+  display: flex;
+`;
+
+const StyledButton = styled.img`
+  cursor: pointer;
+  width: 16px;
+  height: 16px;
+`;
+
+const StyledNumber = styled.button<{ $isActive: boolean }>`
+  color: ${({ $isActive }) => ($isActive ? 'var(--gray-1)' : 'var(--gray-3)')};
+`;
+
+export default Pagination;

--- a/src/components/common/Review/ReviewItem.tsx
+++ b/src/components/common/Review/ReviewItem.tsx
@@ -1,0 +1,106 @@
+import { memo, useState, useRef } from 'react';
+import { Review } from 'src/@types/review';
+import styled from 'styled-components';
+import StarRate from '@components/common/StarRate';
+import useContentHeight from '@hooks/useContentHeight';
+
+const ReviewItem = memo(
+  ({ author, author_details, content, created_at }: Review) => {
+    const [expanded, setExpanded] = useState<boolean>(false);
+    const contentRef = useRef<HTMLDivElement>(null);
+    const contentHeight = useContentHeight({ contentRef });
+
+    const toggleExpanded = () => {
+      setExpanded((prev) => !prev);
+    };
+
+    return (
+      <StyledReviewItem $expanded={expanded}>
+        <StyledReviewInfo>
+          <StyledRateBox>
+            <StyledText>Rate.</StyledText>
+            <StarRate rate={author_details.rating} color={true} />
+          </StyledRateBox>
+          <StyledAuthorBox>
+            <div>{author}</div>
+            <StyledDate>
+              {created_at.slice(0, 10).split('-').join('.')}
+            </StyledDate>
+          </StyledAuthorBox>
+        </StyledReviewInfo>
+        <StyledContent
+          ref={contentRef}
+          $expanded={expanded}
+          $contentHeight={contentHeight}
+        >
+          {content}
+        </StyledContent>
+        {contentHeight && contentHeight >= 120 && !expanded && (
+          <StyledReadMore onClick={toggleExpanded}>Read more</StyledReadMore>
+        )}
+      </StyledReviewItem>
+    );
+  },
+);
+
+ReviewItem.displayName = 'ReviewItem';
+
+const StyledReviewItem = styled.li<{ $expanded: boolean }>`
+  width: 100%;
+  min-height: 200px;
+  max-height: ${({ $expanded }) => ($expanded ? 'auto' : '200px')};
+  overflow: hidden;
+  position: relative;
+  padding: 12px;
+  border: 1px solid var(--gray-4);
+  border-radius: 8px;
+`;
+
+const StyledReviewInfo = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 14px;
+  font-weight: 400;
+  color: var(--gray-1);
+  margin-bottom: 12px;
+`;
+
+const StyledRateBox = styled.div`
+  display: flex;
+  gap: 2px;
+`;
+
+const StyledText = styled.span`
+  line-height: 20px;
+`;
+
+const StyledAuthorBox = styled.div`
+  display: flex;
+  gap: 8px;
+`;
+
+const StyledDate = styled.span`
+  color: var(--gray-3);
+`;
+
+const StyledContent = styled.div<{
+  $expanded: boolean;
+  $contentHeight: number | null;
+}>`
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: ${({ $expanded }) => ($expanded ? 'unset' : '6')};
+  -webkit-box-orient: vertical;
+  line-height: 20px;
+`;
+
+const StyledReadMore = styled.button`
+  color: var(--gray-3);
+  font-size: 12px;
+  border-bottom: 1px solid var(--gray-3);
+  margin: 4px 0;
+  padding: 0;
+`;
+
+export default ReviewItem;

--- a/src/components/common/Tag/index.tsx
+++ b/src/components/common/Tag/index.tsx
@@ -1,0 +1,38 @@
+import { memo } from 'react';
+import styled from 'styled-components';
+
+const Tag = memo(({ text }: { text: string }) => {
+  return (
+    <StyledList>
+      <StyledSpan>
+        <span>#</span>
+        <span>{text}</span>
+      </StyledSpan>
+    </StyledList>
+  );
+});
+
+Tag.displayName = 'Tag';
+
+const StyledList = styled.li`
+  width: fit-content;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border: none;
+  line-height: 1px;
+  background-color: var(--gray-6);
+  padding: 12px 8px;
+  border-radius: 30px;
+  font-size: 14px;
+  word-wrap: break-word;
+`;
+
+const StyledSpan = styled.div`
+  display: flex;
+  gap: 4px;
+  width: 100%;
+  color: var(--gray-3);
+`;
+
+export default Tag;

--- a/src/hooks/useContentHeight.ts
+++ b/src/hooks/useContentHeight.ts
@@ -1,0 +1,21 @@
+import { RefObject, useEffect, useState } from 'react';
+
+interface UseContentHeightProps<T extends HTMLElement> {
+  contentRef: RefObject<T>;
+}
+
+const useContentHeight = <T extends HTMLElement>({
+  contentRef,
+}: UseContentHeightProps<T>) => {
+  const [contentHeight, setContentHeight] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (contentRef.current) {
+      setContentHeight(contentRef.current.clientHeight);
+    }
+  }, [contentRef]);
+
+  return contentHeight;
+};
+
+export default useContentHeight;

--- a/src/pages/Movie.tsx
+++ b/src/pages/Movie.tsx
@@ -1,0 +1,16 @@
+import MovieDetail from '@components/Movie/MovieDetail';
+import Fallback from '@components/common/Fallback';
+import Layout from '@components/common/Layout';
+import { Suspense } from 'react';
+
+const Movie = () => {
+  return (
+    <Layout>
+      <Suspense fallback={<Fallback />}>
+        <MovieDetail />
+      </Suspense>
+    </Layout>
+  );
+};
+
+export default Movie;


### PR DESCRIPTION
- 영화 상세 페이지 구현을 위해 (영화 상세 정보, 영화 상세 리뷰, 영화 추천) 컴포넌트를 구현했습니다.
- `Suspense` 하나에 3개의 api 호출을 통해 `network waterfall`현상을 수정하고, 병렬로 api 요청을 하도록 구현했습니다.
- 추천 영화를 보여주기 위한 `infinite carousel` 컴포넌트를 구현했습니다.
- 리뷰 아이템을 초기에 하나만 보여주도록하고, 리뷰가 없는 경우도 따로 처리해주었습니다. 추가적인 리뷰를 보기 위해서는 버튼을 클릭하여 로드합니다.
- 리뷰 컨텐츠의 길이가 리뷰 박스 사이즈인 `200px`을 넘어가면 `read more` 버튼이 나오도록 구현하고, `read more` 버튼을 클릭하면 나머지 컨텐츠를 볼 수 있도록 구현했습니다.
- 페이지네이션을 구현하여 영화 목록을 넘길 수 있습니다.