### PR TITLE
[Feat] /#11/modal

### DIFF
--- a/src/components/common/Modal/AddModal.tsx
+++ b/src/components/common/Modal/AddModal.tsx
@@ -1,0 +1,104 @@
+import { memo } from 'react';
+import styled from 'styled-components';
+import { ModalProps } from 'src/@types/modal';
+
+const AddModal = memo(({ title, onSubmit, onAbort }: ModalProps) => {
+  const handleOutside = (e: React.MouseEvent) => {
+    if (e.target !== e.currentTarget) return;
+    e.stopPropagation();
+    onAbort?.(new Error());
+  };
+  return (
+    <StyledWrapper onClick={handleOutside}>
+      <StyledContainer>
+        <StyledFlexContainer>
+          <StyledMovieTitle>{title}</StyledMovieTitle>
+          <StyledSpan>
+            선택한 영화가 My Favorite List에 추가되었습니다.
+          </StyledSpan>
+          <StyledSpan>
+            *확인하기 버튼을 눌러 My Favorite List에서
+            <br /> 좋아요한 영화 목록을 확인할 수 있습니다.
+          </StyledSpan>
+          <StyledButtonContainer>
+            <StyledButton
+              onClick={() => onAbort?.(new Error())}
+              $colorType="disabled"
+            >
+              닫기
+            </StyledButton>
+            <StyledButton
+              onClick={() => {
+                onSubmit?.(true);
+              }}
+              $colorType="blue"
+            >
+              확인하기
+            </StyledButton>
+          </StyledButtonContainer>
+        </StyledFlexContainer>
+      </StyledContainer>
+    </StyledWrapper>
+  );
+});
+
+AddModal.displayName = 'AddModal';
+
+const StyledWrapper = styled.div`
+  display: flex;
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(11, 19, 30, 0.37);
+  backdrop-filter: blur(5px);
+  top: 0;
+  left: 0;
+  z-index: 99;
+`;
+
+const StyledContainer = styled.article`
+  width: 560px;
+  height: 273px;
+  margin: auto;
+  padding: 24px;
+  background-color: var(--white);
+  border-radius: 8px;
+  text-align: center;
+`;
+
+const StyledFlexContainer = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+`;
+
+const StyledMovieTitle = styled.h1`
+  font-size: 18px;
+  font-weight: 500;
+  color: var(--gray-1);
+`;
+
+const StyledSpan = styled.span`
+  font-size: 16px;
+  font-weight: 400;
+  white-space: pre-wrap;
+`;
+
+const StyledButtonContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+`;
+
+const StyledButton = styled.button<{ $colorType: 'disabled' | 'blue' }>`
+  width: 100%;
+  padding: 12px;
+  background-color: ${({ $colorType }) =>
+    $colorType === 'blue' ? 'var(--blue-2)' : 'var(--gray-4)'};
+  color: var(--white);
+  border-radius: 8px;
+`;
+
+export default AddModal;

--- a/src/components/common/Modal/DeleteModal.tsx
+++ b/src/components/common/Modal/DeleteModal.tsx
@@ -1,0 +1,85 @@
+import { memo } from 'react';
+import styled from 'styled-components';
+import { ModalProps } from 'src/@types/modal';
+
+const DeleteModal = memo(({ title, onSubmit, onAbort }: ModalProps) => {
+  const handleOutside = (e: React.MouseEvent) => {
+    if (e.target !== e.currentTarget) return;
+    e.stopPropagation();
+    onAbort?.(new Error());
+  };
+  return (
+    <StyledWrapper onClick={handleOutside}>
+      <StyledContainer>
+        <StyledFlexContainer>
+          <StyledMovieTitle>{title}</StyledMovieTitle>
+          <StyledSpan>
+            선택한 영화가 My Favorite List에서 제거되었습니다.
+          </StyledSpan>
+          <StyledButtonContainer>
+            <StyledButton onClick={() => onSubmit?.(true)}>닫기</StyledButton>
+          </StyledButtonContainer>
+        </StyledFlexContainer>
+      </StyledContainer>
+    </StyledWrapper>
+  );
+});
+
+DeleteModal.displayName = 'DeleteModal';
+
+const StyledWrapper = styled.div`
+  display: flex;
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(11, 19, 30, 0.37);
+  backdrop-filter: blur(5px);
+  top: 0;
+  left: 0;
+  z-index: 99;
+`;
+
+const StyledContainer = styled.article`
+  width: 560px;
+  height: 273px;
+  margin: auto;
+  padding: 24px;
+  background-color: var(--white);
+  border-radius: 8px;
+  text-align: center;
+`;
+
+const StyledFlexContainer = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+`;
+
+const StyledMovieTitle = styled.h1`
+  font-size: 18px;
+  font-weight: 500;
+  color: var(--gray-1);
+`;
+
+const StyledSpan = styled.span`
+  font-size: 16px;
+  font-weight: 400;
+`;
+
+const StyledButtonContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+`;
+
+const StyledButton = styled.button`
+  width: 100%;
+  padding: 12px;
+  background-color: var(--gray-4);
+  color: var(--white);
+  border-radius: 8px;
+`;
+
+export default DeleteModal;

--- a/src/context/ModalContext.tsx
+++ b/src/context/ModalContext.tsx
@@ -1,0 +1,75 @@
+import {
+  createContext,
+  useState,
+  useEffect,
+  cloneElement,
+  Fragment,
+} from 'react';
+import { useLocation } from 'react-router-dom';
+
+type ModalProps = {
+  openModal: <T extends {}>(element: React.ReactElement) => Promise<T>;
+  hideModal: () => void;
+  modals: React.ReactElement[];
+};
+
+interface Props {
+  children: JSX.Element | JSX.Element[];
+}
+
+const ModalContext = createContext<ModalProps>({
+  openModal: async () => Promise.resolve({} as any),
+  hideModal: () => {},
+  modals: [],
+});
+
+const ModalProvider = ({ children }: Props): JSX.Element => {
+  const [modals, setModals] = useState<React.ReactElement[]>([]);
+  const location = useLocation();
+
+  useEffect(() => {
+    setModals([]);
+  }, [location]);
+
+  const openModal = <T extends {}>(element: React.ReactElement): Promise<T> => {
+    const promiseResolver = () => {
+      let resolveFn: (value: T) => void = () => {};
+      let rejectFn: (ex: Error) => void = () => {};
+      const promise: Promise<T> = new Promise((resolve, reject) => {
+        resolveFn = resolve;
+        rejectFn = reject;
+      });
+      return { promise, resolveFn, rejectFn };
+    };
+    const { promise, resolveFn, rejectFn } = promiseResolver();
+
+    const modal: React.ReactElement = cloneElement(element, {
+      onSubmit: (value: T) => {
+        resolveFn(value);
+        setModals((prev) => prev.slice(0, -1));
+      },
+      onAbort: (ex: Error) => {
+        rejectFn(ex);
+        setModals((prev) => prev.slice(0, -1));
+      },
+    });
+    setModals((prev) => [...prev, modal]);
+    return promise;
+  };
+
+  const hideModal = () => {
+    modals.at(-1)?.props.onSubmit(false);
+    setModals((prev) => prev.slice(0, -1));
+  };
+
+  return (
+    <ModalContext.Provider value={{ openModal, hideModal, modals }}>
+      {children}
+      {modals.map((modal, idx) => (
+        <Fragment key={idx}>{modal}</Fragment>
+      ))}
+    </ModalContext.Provider>
+  );
+};
+
+export { ModalContext, ModalProvider };


### PR DESCRIPTION
- 컴포넌트 트리 전체에 걸쳐서 상태를 공유하고, `ContextAPI`를 사용할  때, `Provider` 컴포넌트 내에서 상태와 관련된 추가적인 렌더링 로직을 작성하는 특징을 활용해 모달을 관리할 수 있는 `ModalContext`를 구현했습니다.
- `promise`를 활용하여 모달을 구현함으로써 모달 버튼의 액션을 `promise`의 상태를 `fulfilled`로 변경시킵니다. 이 후 반환 값에 따라서 로직을 처리합니다.